### PR TITLE
[packaging] BuildRequire systemd via pkgconfig. JB#55010

### DIFF
--- a/rpm/openssh.spec
+++ b/rpm/openssh.spec
@@ -96,7 +96,7 @@ BuildRequires: autoconf, automake, openssl-devel, perl, zlib-devel
 #BuildRequires: audit-libs-devel
 BuildRequires: util-linux
 BuildRequires: pam-devel
-BuildRequires: systemd
+BuildRequires: pkgconfig(systemd)
 %if %{kerberos5}
 BuildRequires: krb5-devel
 %endif


### PR DESCRIPTION
This allows to pick systemd-mini inside the builder instead of full
systemd.